### PR TITLE
Don't fail when PR is in progress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
         type: string
     steps:
       - run:
-          name: Autocommitting
+          name: "Autocommitting << parameters.dest_repo >>"
           command: bash autocommiter.sh "<< parameters.source_repo >>" "<< parameters.dest_repo >>"
 
 jobs:

--- a/autocommiter.sh
+++ b/autocommiter.sh
@@ -51,7 +51,7 @@ git commit -m ':tada: automated upstream release update'
 echo -e "\e[32mPushing to autoupdate branch in ${DST}\e[0m"
 if ! git push "https://${GH_TOKEN}:@github.com/${DST}" --set-upstream autoupdate; then
     echo -e "\e[33mBranch is already on remote.\e[0m"
-    exit 129
+    exit 0
 fi
 
 PAYLOAD="{\"title\": \"New ${SRC} upstream release!\",


### PR DESCRIPTION
If the branch exists on the remote, don't fail the pipeline.
* Include name of destination in CI tasks.

Signed-off-by: Ben Kochie <superq@gmail.com>