### PR TITLE
Update autocommit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,17 +24,17 @@ jobs:
     steps:
     - checkout
     - autocommit:
-        source_repo: prometheus/alertmanager
-        dest_repo: cloudalchemy/ansible-alertmanager
-    - autocommit:
         source_repo: prometheus/prometheus
         dest_repo: cloudalchemy/ansible-prometheus
+    - autocommit:
+        source_repo: prometheus/alertmanager
+        dest_repo: cloudalchemy/ansible-alertmanager
     - autocommit:
         source_repo: prometheus/blackbox_exporter
         dest_repo: cloudalchemy/ansible-blackbox-exporter
     - autocommit:
-        source_repo: prometheus/snmp_exporter
-        dest_repo: cloudalchemy/ansible-snmp-exporter
+        source_repo: prometheus/memcached_exporter
+        dest_repo: cloudalchemy/ansible-memcached
     - autocommit:
         source_repo: prometheus/mysqld_exporter
         dest_repo: cloudalchemy/ansible-mysqld-exporter
@@ -42,11 +42,17 @@ jobs:
         source_repo: prometheus/pushgateway
         dest_repo: cloudalchemy/ansible-pushgateway
     - autocommit:
-        source_repo: ncabatoff/process-exporter
-        dest_repo: cloudalchemy/ansible-process_exporter
+        source_repo: prometheus/snmp_exporter
+        dest_repo: cloudalchemy/ansible-snmp-exporter
+    - autocommit:
+        source_repo: cortexproject/cortex
+        dest_repo: cloudalchemy/ansible-cortex
     - autocommit:
         source_repo: coredns/coredns
         dest_repo: cloudalchemy/ansible-coredns
+    - autocommit:
+        source_repo: ncabatoff/process-exporter
+        dest_repo: cloudalchemy/ansible-process_exporter
 
 workflows:
   version: 2


### PR DESCRIPTION
Add memcached_exporter and cortex.

New order:

- Prometheus and alertmanager
- Prometheus official repos (a->z)
- Third party repos with (a->z)

This should ensure that the prometheus role stays up to date even if
further steps fail.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>