### PR TITLE
Fix memcached repo name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
         dest_repo: cloudalchemy/ansible-blackbox-exporter
     - autocommit:
         source_repo: prometheus/memcached_exporter
-        dest_repo: cloudalchemy/ansible-memcached
+        dest_repo: cloudalchemy/ansible-memcached-exporter
     - autocommit:
         source_repo: prometheus/mysqld_exporter
         dest_repo: cloudalchemy/ansible-mysqld-exporter


### PR DESCRIPTION
Use correct repo path: cloudalchemy/ansible-memcached-exporter

Signed-off-by: Ben Kochie <superq@gmail.com>